### PR TITLE
fix: enforce server-side model selection & remove client-supplied publicInputs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -153,7 +153,6 @@ const response = await fetch("https://zkllmapi.com/v1/chat", {
     messages: [
       { role: "user", content: "What is Ethereum?" }
     ],
-    model: "llama-3.3-70b",  // any Venice-supported model
   }),
 });
 
@@ -191,16 +190,11 @@ if (spent) {
 
 ---
 
-## Available Models
+## Model
 
-Any model supported by [Venice AI](https://venice.ai/models) works. Popular options:
-- `llama-3.3-70b`
-- `llama-3.1-405b`
-- `mistral-31-24b`
-- `zai-org-glm-5`
-- `deepseek-r1-671b`
+The API server uses a single fixed model: `hermes-3-llama-3.1-405b`. One credit = one call to this model.
 
-Pass any Venice model name in the `model` field — no restrictions.
+The `model` field in the request body is ignored — the server always uses its configured model. Self-hosters can change the model via the `VENICE_MODEL` environment variable.
 
 ---
 
@@ -238,7 +232,6 @@ const res = await fetch("https://zkllmapi.com/v1/chat", {
     root: latestRoot,
     depth: 16,
     messages: [{ role: "user", content: "Hello!" }],
-    model: "llama-3.3-70b",
   }),
 });
 

--- a/packages/api-server/.env.example
+++ b/packages/api-server/.env.example
@@ -4,6 +4,9 @@ VENICE_API_KEY=your_venice_api_key_here
 # Base mainnet contract address — auto-patched by update.sh from https://zkllmapi.com/contract
 CONTRACT_ADDRESS=0x...
 
+# Model sent to Venice AI — one credit = one call to this model
+# VENICE_MODEL=hermes-3-llama-3.1-405b
+
 # Optional overrides
 # VENICE_BASE_URL=https://api.venice.ai/api/v1
 # RPC_URL=https://mainnet.base.org

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -530,13 +530,11 @@ app.post("/v1/chat", async (req, res) => {
 
   const {
     proof,
-    publicInputs: clientPublicInputs,
     nullifier_hash,
     root,
     depth,
     messages,
     encrypted_messages,
-    model: requestedModel,
   } = req.body;
 
   // E2EE mode: encrypted_messages replaces messages
@@ -591,7 +589,7 @@ app.post("/v1/chat", async (req, res) => {
     const tVerifyStart = Date.now();
     console.log(`[${reqId}] starting proof verification (${ts()})`);
     try {
-      const proofValid = await verifyProof(proof, nullifier_hash, root, depth, clientPublicInputs);
+      const proofValid = await verifyProof(proof, nullifier_hash, root, depth);
       const verifyMs = Date.now() - tVerifyStart;
       if (!proofValid) {
         console.log(`[${reqId}] proof INVALID — ${verifyMs}ms`);
@@ -694,11 +692,9 @@ async function verifyProof(
   nullifierHash: string,
   root: string,
   depth: number,
-  clientPublicInputs?: string[]
 ): Promise<boolean> {
   try {
-    // Use public inputs from client if provided (exact encoding from bb.js)
-    const publicInputs = clientPublicInputs ?? [
+    const publicInputs = [
       nullifierHash,
       root,
       "0x" + BigInt(depth).toString(16).padStart(64, "0"),

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -389,7 +389,7 @@ const spentNullifiers = loadNullifiers();
 const pendingNullifiers = new Set<string>();
 
 // ─── Model (locked for demo — one credit, one model) ─────────
-const MODEL = "e2ee-glm-5";
+const MODEL = process.env.VENICE_MODEL || "hermes-3-llama-3.1-405b";
 
 // ─── Express App ──────────────────────────────────────────────
 const app = express();
@@ -537,6 +537,10 @@ app.post("/v1/chat", async (req, res) => {
     encrypted_messages,
   } = req.body;
 
+  if (req.body.model && req.body.model !== MODEL) {
+    console.log(`[${reqId}] client requested model "${req.body.model}" — ignored, using "${MODEL}"`);
+  }
+
   // E2EE mode: encrypted_messages replaces messages
   const isE2EE = !!encrypted_messages;
 
@@ -633,7 +637,7 @@ app.post("/v1/chat", async (req, res) => {
       // Build Venice request body
       // NOTE: always stream: false — server does veniceResponse.json(), not SSE piping
       const veniceBody: Record<string, any> = {
-        model: requestedModel || MODEL,
+        model: MODEL,
         stream: false,
       };
       if (isE2EE) {
@@ -740,6 +744,7 @@ async function start() {
   app.listen(PORT, () => {
     console.log(`\n🔐 ZK API Credits Server`);
     console.log(`   Port: ${PORT}`);
+    console.log(`   Model: ${MODEL}`);
     console.log(`   Venice: ${VENICE_BASE_URL}`);
     console.log(`   VK: ${VK_PATH}`);
     console.log(`   Contract: ${CONTRACT_ADDRESS}`);

--- a/packages/nextjs/app/chat/page.tsx
+++ b/packages/nextjs/app/chat/page.tsx
@@ -48,7 +48,6 @@ export default function ChatPage() {
           root: proofData.root,
           depth: proofData.depth,
           messages: updatedMessages,
-          model: "hermes-3-llama-3.1-405b",
         }),
       });
 


### PR DESCRIPTION
## Summary

Two security fixes for the API server:

- **Remove client-supplied `publicInputs` from proof verification** — The server was accepting `publicInputs` from the request body and passing them to the verifier. A malicious client could supply crafted public inputs to make an invalid proof pass verification. The server now always computes public inputs from `nullifier_hash`, `root`, and `depth`.

- **Enforce server-side model selection** — The `model` field in the request body was being forwarded to Venice AI. Since all credits cost the same on-chain, a user could burn one cheap credit but route to an expensive model (e.g. `deepseek-r1-671b`), making the operator pay the upstream cost difference. The server now ignores the client `model` field and always uses its configured `MODEL` (default: `hermes-3-llama-3.1-405b`, overridable via `VENICE_MODEL` env var).

## Note

The `packages/nextjs/app/chat/page.tsx` change (removing the `model` field from the request body) is probably not relevant since the production frontend is in a separate repo. Included here for completeness.